### PR TITLE
Remove Peek, Lollypop, and Spotify from transition list

### DIFF
--- a/pop_transition/__init__.py
+++ b/pop_transition/__init__.py
@@ -76,14 +76,6 @@ APPS = {
         'old_id': None,
         'deb_pkg': 'keepassxc'
     },
-    'lollypop': {
-        'name': 'Lollypop',
-        'version': '1.2.35',
-        'icon': 'org.gnome.Lollypop',
-        'id': 'org.gnome.Lollypop',
-        'old_id': None,
-        'deb_pkg': 'lollypop'
-    },
     'mattermost': {
         'name': 'Mattermost',
         'version': '4.4.1',
@@ -92,14 +84,6 @@ APPS = {
         'old_id': None,
         'deb_pkg': 'mattermost-desktop'
     },
-    'peek': {
-        'name': 'Peek',
-        'version': '1.5.1',
-        'icon': 'com.uploadedlobster.peek',
-        'id': 'com.uploadedlobster.peek',
-        'old_id': None,
-        'deb_pkg': 'peek'
-    },
     'signal': {
         'name': 'Signal',
         'version': '1.33.4',
@@ -107,14 +91,6 @@ APPS = {
         'id': 'org.signal.Signal',
         'old_id': None,
         'deb_pkg': 'signal-desktop'
-    },
-    'spotify': {
-        'name': 'Spotify',
-        'version': '1.1.26.501',
-        'icon': 'spotify-client',
-        'id': 'com.spotify.Client',
-        'old_id': None,
-        'deb_pkg': 'spotify-client'
     },
     'wire': {
         'name': 'Wire',


### PR DESCRIPTION
Per conversation in https://github.com/pop-os/desktop/pull/50, this removes Peek, Lollypop, and Spotify from the list of apps being transitioned.

* Peek and Lollypop are in Ubuntu's repository now. They will remain available as .debs in the Pop!_Shop, and installing the .deb (the default option) should not notify the user to transition.

* The Spotify .deb package that we've been hosting adds the Spotify repo to the system (`/etc/apt/sources.list.d/spotify.list`), so any users who installed our Spotify deb package will continue to receive .deb updates from them.
  * New installations will have Flatpak as the only option in the Pop!_Shop by default once we remove our .deb package (but can still get the .deb if they add the [Spotify repo](https://www.spotify.com/us/download/linux/).)