### PR TITLE
fix: #11 dont warn about packages from PPAs

### DIFF
--- a/pop_transition/__init__.py
+++ b/pop_transition/__init__.py
@@ -92,6 +92,14 @@ APPS = {
         'old_id': None,
         'deb_pkg': 'signal-desktop'
     },
+    'spotify': {
+        'name': 'Spotify',
+        'version': '1.1.26.501',
+        'icon': 'spotify-client',
+        'id': 'com.spotify.Client',
+        'old_id': None,
+        'deb_pkg': 'spotify-client'
+    },
     'wire': {
         'name': 'Wire',
         'version': '3.17.2924',

--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -131,7 +131,7 @@ class Application(Gtk.Application):
             pkg.source = 'Flathub'
             pkg.app_id = self.app_list[app]['id']
             pkg.deb_package = self.app_list[app]['deb_pkg']
-            if pkg.installed and pkg.upgrade_origin in ("", "system76"):
+            if pkg.installed and pkg.upgrade_origin in ("", "system76", "LP-PPA-system76-pop"):
                 yield pkg
 
     def on_quit_clicked(self, button, data=None):

--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -131,7 +131,7 @@ class Application(Gtk.Application):
             pkg.source = 'Flathub'
             pkg.app_id = self.app_list[app]['id']
             pkg.deb_package = self.app_list[app]['deb_pkg']
-            if pkg.installed and pkg.upgrade_origin == "Ubuntu":
+            if pkg.installed and pkg.upgrade_origin == "":
                 yield pkg
 
     def on_quit_clicked(self, button, data=None):

--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -131,7 +131,7 @@ class Application(Gtk.Application):
             pkg.source = 'Flathub'
             pkg.app_id = self.app_list[app]['id']
             pkg.deb_package = self.app_list[app]['deb_pkg']
-            if pkg.installed:
+            if pkg.installed and pkg.upgrade_origin == "Ubuntu":
                 yield pkg
 
     def on_quit_clicked(self, button, data=None):

--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -131,7 +131,7 @@ class Application(Gtk.Application):
             pkg.source = 'Flathub'
             pkg.app_id = self.app_list[app]['id']
             pkg.deb_package = self.app_list[app]['deb_pkg']
-            if pkg.installed and pkg.upgrade_origin == "":
+            if pkg.installed and pkg.upgrade_origin in ("", "system76"):
                 yield pkg
 
     def on_quit_clicked(self, button, data=None):

--- a/pop_transition/package.py
+++ b/pop_transition/package.py
@@ -141,6 +141,18 @@ class Package(Gtk.Grid):
             return False
 
     @property
+    def upgrade_origin(self):
+        """ str: the origin that will be used if the package is upgraded"""
+        if self.cache is None:
+            self.cache = apt.get_cache()
+
+        try:
+            pkg = self.cache[self.deb_package]
+            return pkg.candidate.origins[0].origin
+        except Exception:
+            return None
+
+    @property
     def name(self):
         """ str: The name of the application. """
         return self.name_label.get_text()


### PR DESCRIPTION
Checks the upgrade candidate's origin to ensure that it is "Ubuntu".
It should be something else if upgrading from a PPA -- in which case
we should not warn.