### PR TITLE
fix: Use of unassigned variable when error occurs

### DIFF
--- a/pop_transition/apt.py
+++ b/pop_transition/apt.py
@@ -77,7 +77,8 @@ class RemoveThread(Thread):
             success = privileged_object.remove_packages(pkg_list)
         
         except:
-            print("Countn't remove one or more packages")
+            print("Couldn't remove one or more packages")
+            success = []
         
         # idle_add(self.window.quit_app)
         for package in self.packages:


### PR DESCRIPTION
When the error "Couldn't remove one or more packages" occurred, this was crashing with the `success` variable used without being assigned.

This should fix the crash in https://github.com/pop-os/transition/issues/17, though not whatever is causing it to fail at removing packages.

I haven't tested on Focal so I don't know the exact behavior.