### PR TITLE
Allow adding/enabling Flathub if it is removed or disabled

### DIFF
--- a/data/flathub-badge.svg
+++ b/data/flathub-badge.svg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="157.52516"
+   height="128.74739"
+   viewBox="0 0 157.52516 128.7474"
+   version="1.1"
+   id="svg8129"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="flathub-badge.svg"
+   inkscape:export-filename="/home/jimmac/SparkleShare/flathub-mockups/assets/download-button/download.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs8123" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="79.466101"
+     inkscape:cy="61.512395"
+     inkscape:document-units="px"
+     inkscape:current-layer="g7734"
+     showgrid="true"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:snap-nodes="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8722"
+       originx="0"
+       originy="-71.25262" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata8126">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-993.77225)">
+    <g
+       transform="translate(-777.25032,177.86342)"
+       id="g8587">
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect7736"
+         d="m 856.01397,830.22631 -66.76365,43.44891 v 34.93973 l 33.38182,21.72315 33.37926,-21.72315 v -0.005 l 0.003,0.003 33.38183,21.72574 33.37925,-21.72315 v -34.93979 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#f6f6f6;stroke-width:24;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <g
+         style="stroke-width:0.75574"
+         transform="matrix(0.50221552,0,0,0.50636711,429.63205,432.90461)"
+         id="g7710">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.16674;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect7688"
+           width="79.110413"
+           height="79.110413"
+           x="1289.9076"
+           y="279.42584"
+           rx="0"
+           ry="0"
+           transform="matrix(0.84019328,0.54228706,-0.84019328,0.54228706,0,0)" />
+        <rect
+           transform="matrix(0.84019328,0.54228706,-0.84019328,0.54228706,0,0)"
+           ry="0"
+           rx="0"
+           y="215.8064"
+           x="1226.2882"
+           height="79.110413"
+           width="79.110413"
+           id="rect7690"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f6f6f6;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.16674;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.02296;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 915.46811,824.92983 -5e-5,68.99997 -66.46803,42.90055 5e-5,-68.99997 z"
+           id="path7692"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7694"
+           d="m 783.00003,824.92983 5e-5,68.99997 66.46803,42.90055 -5e-5,-68.99997 z"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.02296;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+      <g
+         style="stroke-width:0.75574"
+         transform="matrix(0.50221552,0,0,0.50636711,463.01368,454.62849)"
+         id="g7722">
+        <rect
+           transform="matrix(0.84019328,0.54228706,-0.84019328,0.54228706,0,0)"
+           ry="0"
+           rx="0"
+           y="279.42584"
+           x="1289.9076"
+           height="79.110413"
+           width="79.110413"
+           id="rect7714"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.16674;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f6f6f6;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.16674;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect7716"
+           width="79.110413"
+           height="79.110413"
+           x="1226.2882"
+           y="215.8064"
+           rx="0"
+           ry="0"
+           transform="matrix(0.84019328,0.54228706,-0.84019328,0.54228706,0,0)" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7718"
+           d="m 915.46811,824.92983 -5e-5,68.99997 -66.46803,42.90055 5e-5,-68.99997 z"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.02296;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f6f6f6;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.02296;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 783.00003,824.92983 5e-5,68.99997 66.46803,42.90055 -5e-5,-68.99997 z"
+           id="path7720"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         style="stroke-width:0.75574"
+         id="g7734"
+         transform="matrix(0.50221552,0,0,0.50636711,396.25042,454.62849)">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.16674;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect7726"
+           width="79.110413"
+           height="79.110413"
+           x="1289.9076"
+           y="279.42584"
+           rx="0"
+           ry="0"
+           transform="matrix(0.84019328,0.54228706,-0.84019328,0.54228706,0,0)" />
+        <rect
+           transform="matrix(0.84019328,0.54228706,-0.84019328,0.54228706,0,0)"
+           ry="0"
+           rx="0"
+           y="215.8064"
+           x="1226.2882"
+           height="79.110413"
+           width="79.110413"
+           id="rect7728"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f6f6f6;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.16674;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.02296;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 915.46811,824.92983 -5e-5,68.99997 -66.46803,42.90055 5e-5,-68.99997 z"
+           id="path7730"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7732"
+           d="m 783.00003,824.92983 5e-5,68.99997 66.46803,42.90055 -5e-5,-68.99997 z"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f6f6f6;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3.02296;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -37,6 +37,15 @@ from .flathub_dialog import FlathubDialog
 
 _ = gettext.gettext
 
+def get_flathub_disabled():
+    """ Returns whether the Flathub remote is disabled."""
+    flathub_remote = flatpak.get_flathub_remote()
+    if flathub_remote:
+        return flathub_remote.get_disabled()
+    else:
+        return 'no_flathub'
+    
+
 class Application(Gtk.Application):
     """ Application class"""
 
@@ -57,10 +66,17 @@ class Application(Gtk.Application):
                 self.window.app_list.add_package(package)
         self.connect_signals(self.window)
         self.window.show_all()
-        response = self.flathub_dialog.run()
-        self.flathub_dialog.destroy()
+        response = None
+        if get_flathub_disabled() == True:
+            self.flathub_dialog.setup_for_disabled()
+            response = self.flathub_dialog.run()
+        elif get_flathub_disabled() == 'no_flathub':
+            self.flathub_dialog.setup_for_missing()
+            response = self.flathub_dialog.run()
         if response == Gtk.ResponseType.CANCEL:
+            self.flathub_dialog.destroy()
             self.quit()
+        self.flathub_dialog.destroy()
     
     def connect_signals(self, window):
         """ Connect signals to their functionality."""

--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -33,6 +33,7 @@ from . import dismissal
 from . import flatpak
 from .package import Package
 from .window import Window
+from .flathub_dialog import FlathubDialog
 
 _ = gettext.gettext
 
@@ -51,10 +52,15 @@ class Application(Gtk.Application):
         print('showing window')
         self.withdraw_notification('transition-ready')
         self.window = Window(self)
+        self.flathub_dialog = FlathubDialog(self.window)
         for package in self.get_installed_packages():
                 self.window.app_list.add_package(package)
         self.connect_signals(self.window)
         self.window.show_all()
+        response = self.flathub_dialog.run()
+        self.flathub_dialog.destroy()
+        if response == Gtk.ResponseType.CANCEL:
+            self.quit()
     
     def connect_signals(self, window):
         """ Connect signals to their functionality."""

--- a/pop_transition/flathub_dialog.py
+++ b/pop_transition/flathub_dialog.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+"""
+Copyright (c) 2020 Ian Santopietro
+Copyright (c) 2020 System76, Inc.
+All rights reserved.
+
+This file is part of Pop-Transition.
+
+    Pop-Transition is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Pop-Transition is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Pop-Transition.  If not, see <https://www.gnu.org/licenses/>.
+
+pop-transition - dialog to add Flathub if it is missing.
+"""
+
+import gettext
+from gi.repository import Gtk
+
+_ = gettext.gettext
+
+class FlathubDialog(Gtk.Dialog):
+    """ Dialog to add Flathub if it is missing."""
+
+    def __init__(self, main_window, *args, **kwargs):
+        super().__init__(
+            '',
+            main_window,
+            0,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OK, Gtk.ResponseType.OK),
+            *args,
+            modal=1,
+            use_header_bar=True,
+            **kwargs
+        )
+        
+        self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
+        self.set_transient_for(main_window)
+
+        self.content_area = self.get_content_area()
+        
+        self.content_grid = Gtk.Grid()
+        self.content_grid.set_row_spacing(6)
+        self.content_grid.set_column_spacing(12)
+        self.content_grid.props.margin = 12
+        self.content_area.add(self.content_grid)
+
+        self.flathub_image = Gtk.Image.new_from_file(
+            '/usr/lib/pop-transition/flathub-badge.svg'
+        )
+        self.content_grid.attach(self.flathub_image, 0, 0, 1, 2)
+
+        self.message_title = Gtk.Label()
+        self.message_title.set_line_wrap(True)
+        self.message_title.set_width_chars(40)
+        self.content_grid.attach(self.message_title, 1, 0, 1, 1)
+
+        self.message = Gtk.Label()
+        self.message.set_line_wrap(True)
+        self.message.set_width_chars(40)
+        self.content_grid.attach(self.message, 1, 1, 1, 1)
+
+        self.ok_button = self.get_widget_for_response(Gtk.ResponseType.OK)
+        Gtk.StyleContext.add_class(
+            self.ok_button.get_style_context(),
+            'suggested-action'
+        )
+
+        # Future code here.
+
+        self.show_all()
+
+        # Testing code here.
+        self.setup_for_disabled()
+
+    def setup_for_missing(self):
+        """ Set up the dialog for adding a missing Flathub remote."""
+        
+        # Message title
+        message_title_text = _('Flahub not detected')
+        self.message_title.set_markup(f'<b>{message_title_text}</b>')
+        
+        # Message text
+        message_text = _(
+            'Flathub was not detected as a flatpak remote on your system. You '
+            'will need to add it to install updated applications.'
+        )
+        self.message.set_text(message_text)
+        self.ok_button.set_label(_('Add Flathub'))
+
+    def setup_for_disabled(self):
+        """ Set up the dialog for adding a disabled Flathub remote."""
+        
+        # Message title
+        message_title_text = _('Flahub is disabled')
+        self.message_title.set_markup(f'<b>{message_title_text}</b>')
+        
+        # Message text
+        message_text = _(
+            'Flathub is currently disabled on your system. You will need to '
+            'enable it to install updated applications.\n\n'
+            'After installation you can re-disable Flathub from the Pop_Shop '
+            'settings.'
+        )
+        self.message.set_text(message_text)
+        self.ok_button.set_label(_('Enable Flathub'))

--- a/pop_transition/flathub_dialog.py
+++ b/pop_transition/flathub_dialog.py
@@ -133,7 +133,7 @@ class FlathubDialog(Gtk.Dialog):
         message_text = _(
             'Flathub is currently disabled on your system. You will need to '
             'enable it to install updated applications.\n\n'
-            'After installation you can re-disable Flathub from the Pop_Shop '
+            'After installation, you can re-disable Flathub from the Pop!_Shop '
             'settings, although it is recommended to leave it enabled to allow '
             'for future updates.'
         )

--- a/pop_transition/flathub_dialog.py
+++ b/pop_transition/flathub_dialog.py
@@ -149,7 +149,7 @@ class FlathubDialog(Gtk.Dialog):
         # We do this in a thread because we don't know how long it will take 
         # to download the flatpakrepo file or how long it will take to save to
         # the disk. This prevents the GUI from locking up. 
-        add_thread = AddThread(self, 'Flathub', FLATPAKREPO_URL)
+        add_thread = AddThread(self, FLATPAKREPO_URL)
         self.spinner.start()
         self.set_sensitive(False)
         add_thread.start()
@@ -166,10 +166,9 @@ class FlathubDialog(Gtk.Dialog):
 
 class AddThread(Thread):
 
-    def __init__(self, dialog, name, url):
+    def __init__(self, dialog, url):
         super().__init__()
         self.dialog = dialog
-        self.name = name
         self.url = url
 
     def run(self):
@@ -179,7 +178,7 @@ class AddThread(Thread):
             a, contents, b = repofile.load_contents()
             repodata = GLib.Bytes.new(contents)
             
-            new_remote = Flatpak.Remote.new_from_file(self.name, repodata)
+            new_remote = Flatpak.Remote.new_from_file('flathub', repodata)
             installation.add_remote(new_remote, True, None)
         
         except GLib.Error as e:

--- a/pop_transition/flathub_dialog.py
+++ b/pop_transition/flathub_dialog.py
@@ -134,7 +134,8 @@ class FlathubDialog(Gtk.Dialog):
             'Flathub is currently disabled on your system. You will need to '
             'enable it to install updated applications.\n\n'
             'After installation you can re-disable Flathub from the Pop_Shop '
-            'settings.'
+            'settings, although it is recommended to leave it enabled to allow '
+            'for future updates.'
         )
         self.message.set_text(message_text)
         self.status.set_text(_('Enabling Flathub'))

--- a/pop_transition/flatpak.py
+++ b/pop_transition/flatpak.py
@@ -69,6 +69,11 @@ class InstallThread(Thread):
         self.flathub = get_flathub_remote()
     
     def run(self):
+        print('Updating Appstream Data')
+        # If the appstream data is out of date, it can cause problems installing
+        # some applications. So we update it first.
+        self.user.update_appstream_full_sync(self.flathub.get_name())
+
         print('Installing Flatpaks...')
         
         # We use a transaction to get error details and to install dependencies 

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ setup(
         ('/usr/share/applications', ['data/org.pop_os.transition.desktop']),
         ('/usr/share/polkit-1/actions', ['data/org.pop_os.transition.policy']),
         ('/etc/dbus-1/system.d/', ['data/org.pop_os.transition.conf']),
-        ('/usr/lib/pop-transition', ['data/service.py']),
+        ('/usr/lib/pop-transition', ['data/service.py', 'data/flathub-badge.svg']),
         ('/etc/xdg/autostart', ['data/org.pop_os.transition.Notify.desktop'])
     ],
     scripts=['bin/pop-transition']


### PR DESCRIPTION
If flathub is not present or is disabled, the transition will hang at the "Waiting" stage indefinitely. This change adds a dialog which informs the user about the problem, and offers to automatically correct it. If the user declines to fix it, Transition will close without applying any changes, to prevent the indefinite hang.

Works when flathub is either disabled, or missing entirely. 

Fixes #15

Additionally, since re-adding flathub appears to occasionally cause issues, this PR will also attempt to repair the existing flatpak installation and update the appstream data from the remotes. 

Fixes #14 