### PR TITLE
fix(application): only migrate configs when package is checked

### DIFF
--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -145,7 +145,7 @@ class Application(Gtk.Application):
         flatpak.install_flatpaks(install_flatpaks, window)
 
         for package in window.app_list.packages:
-            if package.checkbox.get_active:
+            if package.checkbox.get_active():
                 if package.old_config and package.new_config:
                         package.status = 'Migrating configuration'
                         try:


### PR DESCRIPTION
Bad comparison meant that all applications were migrated. This corrects that behavior.

Fixes #20