### PR TITLE
switch GObject.MainLoop with GLib.MainLoop

### DIFF
--- a/data/service.py
+++ b/data/service.py
@@ -235,6 +235,6 @@ if __name__ == "__main__":
     bus = dbus.SystemBus()
     name = dbus.service.BusName('org.pop_os.transition_system', bus)
     object = Transition(bus, '/PopTransition')
-    mainloop = GObject.MainLoop()
+    mainloop = GLib.MainLoop()
 
     mainloop.run()


### PR DESCRIPTION
This PR corrects a PyGIDeprecationWarning in logs as GObject.MainLoop is deprecated, here is the message in logs:

```code
org.pop_os.transition_system[6911]: /usr/lib/pop-transition/service.py:238: PyGIDeprecationWarning: GObject.MainLoop is deprecated; use GLib.MainLoop instead
```