### PR TITLE
Error Management

### DIFF
--- a/bin/pop-transition
+++ b/bin/pop-transition
@@ -45,10 +45,22 @@ Options:
             transition, a notification will be displayed. The daemon will then 
             exit after 10 seconds.
 """
-    
+import logging
+import sys
+
+formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+log = logging.getLogger('pop-transition')
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+if 'debug' in sys.argv:
+    handler.setLevel(logging.DEBUG)
+else:
+    handler.setLevel(logging.WARNING)
+log.addHandler(handler)
+log.setLevel(logging.DEBUG)
+log.debug('Set up logging')
 
 import pop_transition
-import sys
 
 if len(sys.argv) < 1:
     pop_transition.run_window()

--- a/pop_transition/application.py
+++ b/pop_transition/application.py
@@ -25,6 +25,7 @@ pop-transition - Main Application
 
 import gettext
 import shutil
+from logging import getLogger
 
 from gi.repository import Gtk, Gio
 
@@ -53,12 +54,14 @@ class Application(Gtk.Application):
         self.app_list = app_list
         super().__init__(application_id='org.pop_os.transition',
                          flags=Gio.ApplicationFlags.REPLACE)
+        
+        self.log = getLogger('pop-transition.app')
     
     def do_activate(self):
         self.show_window()
     
     def show_window(self, action=None, data=None):
-        print('showing window')
+        self.log.info('showing window')
         self.withdraw_notification('transition-ready')
         self.window = Window(self)
         self.flathub_dialog = FlathubDialog(self.window)
@@ -111,7 +114,7 @@ class Application(Gtk.Application):
 
     
     def on_remove_clicked(self, button, window, data=None):
-        print('Remove Clicked')
+        self.log.info('Remove Clicked')
         window.set_buttons_sensitive(False)
         remove_debs = []
 
@@ -129,7 +132,7 @@ class Application(Gtk.Application):
         apt.remove_debs(remove_debs, window)
     
     def on_install_clicked(self, button, window, data=None):
-        print('Install clicked')
+        self.log.info('Install clicked')
         window.set_buttons_sensitive(False)
         install_flatpaks = []
         
@@ -153,11 +156,11 @@ class Application(Gtk.Application):
                         except shutil.Error:
                             msg = f'Could not copy config for {package.name} '
                             msg += f'from {package.old_config} to {package.new_config}.'
-                            print(msg)
+                            self.log.info(msg)
                         except FileExistsError:
                             msg = f'Config for {package.name} already exists in '
                             msg += f'{package.new_config}.'
-                            print(msg)
+                            self.log.error(msg)
     
     def get_installed_packages(self):
         """ Yield a list of installed Packages."""
@@ -208,7 +211,7 @@ class Notification(Application):
             pkgs.append(pkg)
         
         if len(pkgs) > 0:
-            print('Showing notification')
+            self.log.info('Showing notification')
             notification = Gio.Notification.new(_('Transition to Flatpak'))
             notification.set_body(
                 _(
@@ -220,7 +223,7 @@ class Notification(Application):
             icon = Gio.ThemedIcon.new('system-software-update')
             notification.set_icon(icon)
             notification.set_default_action('app.show-window')
-            print(notification)
+            self.log.error(notification)
             self.send_notification('transition-ready', notification)
         else:
             self.quit()

--- a/pop_transition/apt.py
+++ b/pop_transition/apt.py
@@ -129,12 +129,12 @@ class RemoveThread(Thread):
             self.log.info('Opening cache')
             privileged_object.open_cache()
             self.cache_open = True
-        except Exception as e:
-            self.log.error('Could not open package cache: %s', e)
+        except Exception as exc:
+            self.log.error('Could not open package cache: %s', exc)
             idle_add(
                 self.window.show_error,
                 'Packages could not be removed',
-                str(e)
+                exc
             )
             self.cache_open = False
     

--- a/pop_transition/apt.py
+++ b/pop_transition/apt.py
@@ -101,7 +101,8 @@ class RemoveThread(Thread):
                 idle_add(
                     self.window.show_error,
                     'Packages could not be removed',
-                    error
+                    error,
+                    None
                 )
                 self.cache_open = False
                 idle_add(self.window.show_summary_page)
@@ -164,7 +165,8 @@ class RemoveThread(Thread):
             idle_add(
                 self.window.show_error,
                 'Packages could not be removed',
-                exc
+                exc,
+                None
             )
             self.cache_open = False
     
@@ -182,7 +184,8 @@ class RemoveThread(Thread):
             idle_add(
                 self.window.show_error,
                 'Packages could not be removed',
-                str(e)
+                e,
+                None
             )
             self.success = []
     
@@ -195,7 +198,8 @@ class RemoveThread(Thread):
             idle_add(
                 self.window.show_error,
                 'Packages could not be removed',
-                str(e)
+                e,
+                None
             )
             self.success = []
 
@@ -208,7 +212,8 @@ class RemoveThread(Thread):
             idle_add(
                 self.window.show_error,
                 'Package system error',
-                str(e)
+                e,
+                None
             )
 
     def release(self):

--- a/pop_transition/apt.py
+++ b/pop_transition/apt.py
@@ -30,7 +30,7 @@ import dbus
 
 from apt.cache import Cache
 import apt_pkg
-from gi.repository.GObject import idle_add
+from gi.repository.GLib import idle_add
 from threading import Thread
 
 CACHE = Cache()
@@ -115,6 +115,11 @@ class RemoveThread(Thread):
                     success.append(removed)
         except Exception as e:
             self.log.error(f'Something went wrong: {e}')
+            idle_add(
+                self.window.show_error,
+                'Packages could not be removed',
+                str(e)
+            )
             success = []
         
         try:
@@ -123,6 +128,11 @@ class RemoveThread(Thread):
             privileged_object.close_cache()
         except Exception as e:
             self.log.error(f'Something went wrong: {e}')
+            idle_add(
+                self.window.show_error,
+                'Packages could not be removed',
+                str(e)
+            )
             success = []
 
         # Don't exit until the lock is released.

--- a/pop_transition/flatpak.py
+++ b/pop_transition/flatpak.py
@@ -24,6 +24,8 @@ pop-transition - flatpak interface module.
 """
 
 import subprocess
+from logging import getLogger
+
 from threading import Thread
 from gi.repository import Flatpak, GLib
 from gi.repository.GObject import idle_add
@@ -64,6 +66,7 @@ class InstallThread(Thread):
 
     def __init__(self, packages, window):
         super().__init__()
+        self.log = getLogger('pop-transition.flatpak')
         self.packages = packages
         self.window = window
         self.user = get_user_installation()
@@ -71,18 +74,18 @@ class InstallThread(Thread):
     
     def run(self):
         idle_add(self.packages[0].set_status_text, 'Updating Appstream Data')
-        print("Repairing Flatpak installation")
+        self.log.info("Repairing Flatpak installation")
         # Sometimes this appears to cause issues, so we need to do a quick 
         # repair first to ensure that the local installation is consistent.
         # See https://github.com/flatpak/flatpak/issues/4095
         subprocess.run(['flatpak', 'repair', '--user'])
 
-        print('Updating Appstream Data')
+        self.log.info('Updating Appstream Data')
         # If the appstream data is out of date, it can cause problems installing
         # some applications. So we update it first.
         self.user.update_appstream_full_sync(self.flathub.get_name())
 
-        print('Installing Flatpaks...')
+        self.log.info('Installing Flatpaks...')
         idle_add(self.packages[0].set_status_text, 'Waiting')
         
         # We use a transaction to get error details and to install dependencies 
@@ -92,7 +95,7 @@ class InstallThread(Thread):
         transaction.connect('operation-error', self.on_operation_error)
 
         for package in self.packages:
-            print(f'Installing {package.name} flatpak {package.app_id}.')
+            self.log.debug(f'Installing {package.name} flatpak {package.app_id}.')
             remote_ref = self.user.fetch_remote_ref_sync(
                 self.flathub.get_name(),
                 Flatpak.RefKind.APP,
@@ -124,11 +127,11 @@ class InstallThread(Thread):
     def get_package_from_operation(self, operation):
         ref = operation.get_ref()
         ref_name = ref.split('/')[1]
-        print(f'Looking for ID from ref {ref}')
+        self.log.debug(f'Looking for ID from ref {ref}')
 
         for package in self.packages:
             if ref_name == package.app_id:
-                print(f'Found ID {ref_name} in package {package.name}')
+                self.log.debug(f'Found ID {ref_name} in package {package.name}')
                 return package
     
     def on_new_operation(self, transaction, operation, progress):

--- a/pop_transition/window.py
+++ b/pop_transition/window.py
@@ -140,6 +140,9 @@ class Window(Gtk.ApplicationWindow):
         }
         pages[page]()
     
+    def show_error(self, message_title:str, message_text:str) -> None:
+        """Show an error dialog"""
+
     def move_pages(self, button):
         """ Move to the next or previous page."""
         current_index = self.pages.index(self.current_page)
@@ -294,3 +297,41 @@ class Window(Gtk.ApplicationWindow):
         self.set_buttons_sensitive(True)
         self._current_page = 'summary'
         self.set_visible_buttons()
+
+class ErrorDialog(Gtk.Dialog):
+    def __init__(self, 
+                 window: Gtk.Window, 
+                 message_title: str, 
+                 message_text: str) -> None:
+
+        super().__init__(use_header_bar=True, modal=1)
+        self.set_deletable(False)
+        self.set_transient_for(window)
+
+        self.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.OK)
+
+        content_area = self.get_content_area()
+
+        content_grid = Gtk.Grid()
+        content_grid.set_margin_top(24)
+        content_grid.set_margin_left(24)
+        content_grid.set_margin_right(24)
+        content_grid.set_margin_bottom(24)
+        content_grid.set_column_spacing(36)
+        content_grid.set_row_spacing(12)
+        content_area.add(content_grid)
+
+        error_image = Gtk.Image.new_from_icon_name(
+            'warning-symbolic',
+            Gtk.IconSize.DIALOG
+        )
+        content_grid.attach(error_image, 0, 0, 1, 2)
+
+        dialog_label = Gtk.Label()
+        dialog_label.set_markup(f'<b>{message_title}</b>')
+        content_grid.attach(dialog_label, 1, 0, 1, 1)
+
+        dialog_message = Gtk.Label.new(message_text)
+        content_grid.attach(dialog_message, 1, 1, 1, 1)
+
+        self.show_all()

--- a/pop_transition/window.py
+++ b/pop_transition/window.py
@@ -452,13 +452,11 @@ class ErrorDialog(Gtk.Dialog):
             if app.get_name() == 'Repoman':
                 repoman_app = app
                 break
-        print(repoman_app.get_name())
         if repoman_app:
             repoman_button = Gtk.Button.new_with_label(
                 _('Open Software Sources')
             )
             repoman_button.connect('clicked', self.launch_repoman, repoman_app)
-            print(repoman_button)
             self.content_grid.attach(repoman_button, 1, 2, 1, 1)
             repoman_button.show()
     

--- a/pop_transition/window.py
+++ b/pop_transition/window.py
@@ -175,6 +175,14 @@ class Window(Gtk.ApplicationWindow):
                 )
                 dialog.add_repos_button()
                 break
+            
+            if 'org.pop_os.transition_system.PermissionDeniedByPolicy' in line:
+                message_translated = (
+                    'Administrator privileges are required to remove old Debian '
+                    'packages from the system.'
+                )
+                dialog.expander.hide()
+                break
         
         return message_translated
                     
@@ -373,14 +381,14 @@ class ErrorDialog(Gtk.Dialog):
         self.dialog_message.set_width_chars(1)
         self.content_grid.attach(self.dialog_message, 1, 1, 1, 1)
 
-        expander = Gtk.Expander.new('Error details:')
-        self.content_grid.attach(expander, 0, 3, 2, 1)
+        self.expander = Gtk.Expander.new('Error details:')
+        self.content_grid.attach(self.expander, 0, 3, 2, 1)
 
         traceback_scroll = Gtk.ScrolledWindow()
         traceback_scroll.set_vexpand(True)
         traceback_scroll.set_hexpand(True)
         traceback_scroll.set_size_request(-1, 200)
-        expander.add(traceback_scroll)
+        self.expander.add(traceback_scroll)
 
         traceback_label = Gtk.TextView.new()
         traceback_text = traceback_label.get_buffer()

--- a/pop_transition/window.py
+++ b/pop_transition/window.py
@@ -142,6 +142,9 @@ class Window(Gtk.ApplicationWindow):
     
     def show_error(self, message_title:str, message_text:str) -> None:
         """Show an error dialog"""
+        self.error = ErrorDialog(self, message_title, message_text)
+        self.error.run()
+        self.error.destroy()
 
     def move_pages(self, button):
         """ Move to the next or previous page."""

--- a/pop_transition/window.py
+++ b/pop_transition/window.py
@@ -374,10 +374,18 @@ class ErrorDialog(Gtk.Dialog):
         self.content_grid.attach(self.dialog_message, 1, 1, 1, 1)
 
         expander = Gtk.Expander.new('Error details:')
-        traceback_label = Gtk.Label.new('\n'.join(traceback.format_exception(exception)))
-        traceback_label.set_line_wrap(True)
-        expander.add(traceback_label)
         self.content_grid.attach(expander, 0, 3, 2, 1)
+
+        traceback_scroll = Gtk.ScrolledWindow()
+        traceback_scroll.set_vexpand(True)
+        traceback_scroll.set_hexpand(True)
+        traceback_scroll.set_size_request(-1, 200)
+        expander.add(traceback_scroll)
+
+        traceback_label = Gtk.TextView.new()
+        traceback_text = traceback_label.get_buffer()
+        traceback_text.set_text('\n'.join(traceback.format_exception(exception)))
+        traceback_scroll.add(traceback_label)
 
         self.show_all()
     


### PR DESCRIPTION
Prior, Transition would not display any error messages to users when a process went wrong apart from issues installing individual flatpaks. This means that it is possible that a package removal from Apt can fail silently and not present any negative status to the user apart from an empty summary page. There are also no details about the removal that aid the user in solving problems.

This adds error dialogs to Transition including helpful versions of the most common error messages. The python stack trace is included (collapsed) to aid in advanced/support diagnostics. Additionally, if a problem requires changes to Apt (i.e. the system has an invalid repository added), then the error dialog also includes a button to open Repoman and correct the issue. 